### PR TITLE
Document list filtering options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PROJECT := ssclient
-.DEFAULT_GOAL := ssclienttest
+.DEFAULT_GOAL := ssclient
 UNAME_OS := $(shell uname -s)
 UNAME_ARCH := $(shell uname -m)
 CACHE_BASE ?= $(HOME)/.cache/$(PROJECT)
@@ -24,13 +24,15 @@ $(MOCKGEN):
 	@mkdir -p $(dir $(MOCKGEN))
 	@touch $(MOCKGEN)
 
-.PHONY: ssclienttest
-ssclienttest: $(MOCKGEN)
+.PHONY: examplemocks
+examplemocks: $(MOCKGEN)
+	cd $(CURDIR)/example && mockgen -typed -destination=./adapter/adapter.go -package=adapter github.com/microsoft/kiota-abstractions-go RequestAdapter
 
 .PHONY: ssclient
 ssclient:
+	@which kiota > /dev/null 2>&1 || (echo "kiota not found in PATH, download v1.14.0 from: https://learn.microsoft.com/en-ca/openapi/kiota/install" && exit 1)
 	rm -rf $(CURDIR)/kiota
-	/tmp/kiota/kiota generate --language go --class-name Client --namespace-name go.artefactual.dev/ssclient/kiota --openapi typespec/tsp-output/@typespec/openapi3/openapi.yaml --output ./kiota
+	kiota generate --language go --class-name Client --namespace-name go.artefactual.dev/ssclient/kiota --openapi typespec/tsp-output/@typespec/openapi3/openapi.v1.yaml --output ./kiota
 	mv $(CURDIR)/kiota/goescaped/artefactual/dev/ssclient/kiota/* kiota/
 	rm -rf $(CURDIR)/kiota/goescaped/
 	$(MAKE) update-kiota-imports

--- a/README.md
+++ b/README.md
@@ -1,7 +1,32 @@
 # ssclient
 
 [![PkgGoDev](https://pkg.go.dev/badge/go.artefactual.dev/ssclient)](https://pkg.go.dev/go.artefactual.dev/ssclient)
+[![OpenAPI spec](https://img.shields.io/badge/openapi-spec-orange?logo=openapiinitiative&color=6BA539)][openapi-schema]
 
 This repository provides the `go.artefactual.dev/ssclient` module.
 
 The API is still **experimental**, breaking changes MAY occur.
+
+## Inspecting the API schema
+
+This repository describes the Archivematica Storage Service API using TypeSpec.
+The OpenAPI specification has been generated and is available at
+[openapi.v1.yaml][openapi-schema]. It is not yet complete but we'll be extending
+support as needed.
+
+The API service is built with [TastyPie] which includes built-in schema
+inspection capabilities which has been instrumental for this project, for
+example:
+
+    curl http://127.0.0.1:62081/api/v2/?fullschema=true
+
+Visit [ss-schema.json] to see the output. We should explore options for
+using this feature. [django-tastypie-swagger] could be a really good start since
+it's already doing all the mapping. TypeSpec could be a target by using the
+[emitter framework].
+
+[openapi-schema]: https://raw.githubusercontent.com/artefactual-labs/ssclient-go/main/typespec/tsp-output/%40typespec/openapi3/openapi.v1.yaml
+[TastyPie]: https://django-tastypie.readthedocs.io/
+[ss-schema.json]: https://gist.github.com/sevein/379f101ab9305235844c1e5101eeba04
+[django-tastypie-swagger]: https://github.com/concentricsky/django-tastypie-swagger
+[emitter framework]: https://typespec.io/docs/next/extending-typespec/emitter-framework

--- a/example/main_test.go
+++ b/example/main_test.go
@@ -18,6 +18,8 @@ import (
 )
 
 func assertEqual(t *testing.T, got, want interface{}) {
+	t.Helper()
+
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("Mismatch found:\nGot: %#v\nWant: %#v", got, want)
 	}
@@ -27,8 +29,8 @@ func TestRunUsage(t *testing.T) {
 	ctx := context.Background()
 	stdout := bytes.NewBuffer([]byte{})
 
-	err := run(ctx, stdout, []string{"example"})
-	assertEqual(t, err.Error(), "Usage: example -url=http://127.0.0.1:62081 -user=test -key=test")
+	err := run(ctx, stdout, []string{})
+	assertEqual(t, err.Error(), "flag: help requested")
 }
 
 func TestRun(t *testing.T) {
@@ -71,7 +73,7 @@ func TestRun(t *testing.T) {
 	}))
 	t.Cleanup(func() { srv.Close() })
 
-	if err := run(ctx, stdout, []string{"-url=" + srv.URL, "-user=test", "-key=test"}); err != nil {
+	if err := run(ctx, stdout, []string{"example", "-url=" + srv.URL, "-user=test", "-key=test"}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/kiota/api/v2_location_request_builder.go
+++ b/kiota/api/v2_location_request_builder.go
@@ -10,12 +10,28 @@ import (
 type V2LocationRequestBuilder struct {
     i2ae4187f7daee263371cb1c977df639813ab50ffa529013b7437480d1ec0158f.BaseRequestBuilder
 }
+type V2LocationRequestBuilderGetQueryParameters struct {
+    Description *string `uriparametername:"description"`
+    Limit *int32 `uriparametername:"limit"`
+    Offset *int32 `uriparametername:"offset"`
+    Order_by *string `uriparametername:"order_by"`
+    Pipeline__uuid *string `uriparametername:"pipeline__uuid"`
+    // Deprecated: This property is deprecated, use PurposeAsLocationPurpose instead
+    Purpose *string `uriparametername:"purpose"`
+    PurposeAsLocationPurpose *i2b7a3625368152c59661ed1a63c26960f7e9cda05d0fbc8e5d79ac57ca250e0a.LocationPurpose `uriparametername:"purpose"`
+    Quota *int32 `uriparametername:"quota"`
+    Relative_path *string `uriparametername:"relative_path"`
+    Used *int32 `uriparametername:"used"`
+    Uuid *string `uriparametername:"uuid"`
+}
 // V2LocationRequestBuilderGetRequestConfiguration configuration for the request such as headers, query parameters, and middleware options.
 type V2LocationRequestBuilderGetRequestConfiguration struct {
     // Request headers
     Headers *i2ae4187f7daee263371cb1c977df639813ab50ffa529013b7437480d1ec0158f.RequestHeaders
     // Request options
     Options []i2ae4187f7daee263371cb1c977df639813ab50ffa529013b7437480d1ec0158f.RequestOption
+    // Request query parameters
+    QueryParameters *V2LocationRequestBuilderGetQueryParameters
 }
 // ByUuid gets an item from the go.artefactual.dev/ssclient/kiota.api.v2.location.item collection
 // returns a *V2LocationWithUuItemRequestBuilder when successful
@@ -32,7 +48,7 @@ func (m *V2LocationRequestBuilder) ByUuid(uuid string)(*V2LocationWithUuItemRequ
 // NewV2LocationRequestBuilderInternal instantiates a new V2LocationRequestBuilder and sets the default values.
 func NewV2LocationRequestBuilderInternal(pathParameters map[string]string, requestAdapter i2ae4187f7daee263371cb1c977df639813ab50ffa529013b7437480d1ec0158f.RequestAdapter)(*V2LocationRequestBuilder) {
     m := &V2LocationRequestBuilder{
-        BaseRequestBuilder: *i2ae4187f7daee263371cb1c977df639813ab50ffa529013b7437480d1ec0158f.NewBaseRequestBuilder(requestAdapter, "{+baseurl}/api/v2/location", pathParameters),
+        BaseRequestBuilder: *i2ae4187f7daee263371cb1c977df639813ab50ffa529013b7437480d1ec0158f.NewBaseRequestBuilder(requestAdapter, "{+baseurl}/api/v2/location{?description*,limit*,offset*,order_by*,pipeline__uuid*,purpose*,quota*,relative_path*,used*,uuid*}", pathParameters),
     }
     return m
 }
@@ -66,6 +82,9 @@ func (m *V2LocationRequestBuilder) Get(ctx context.Context, requestConfiguration
 func (m *V2LocationRequestBuilder) ToGetRequestInformation(ctx context.Context, requestConfiguration *V2LocationRequestBuilderGetRequestConfiguration)(*i2ae4187f7daee263371cb1c977df639813ab50ffa529013b7437480d1ec0158f.RequestInformation, error) {
     requestInfo := i2ae4187f7daee263371cb1c977df639813ab50ffa529013b7437480d1ec0158f.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(i2ae4187f7daee263371cb1c977df639813ab50ffa529013b7437480d1ec0158f.GET, m.BaseRequestBuilder.UrlTemplate, m.BaseRequestBuilder.PathParameters)
     if requestConfiguration != nil {
+        if requestConfiguration.QueryParameters != nil {
+            requestInfo.AddQueryParameters(*(requestConfiguration.QueryParameters))
+        }
         requestInfo.Headers.AddAll(requestConfiguration.Headers)
         requestInfo.AddRequestOptions(requestConfiguration.Options)
     }

--- a/kiota/api/v2_pipeline_request_builder.go
+++ b/kiota/api/v2_pipeline_request_builder.go
@@ -1,12 +1,27 @@
 package api
 
 import (
+    "context"
     i2ae4187f7daee263371cb1c977df639813ab50ffa529013b7437480d1ec0158f "github.com/microsoft/kiota-abstractions-go"
+    i2b7a3625368152c59661ed1a63c26960f7e9cda05d0fbc8e5d79ac57ca250e0a "go.artefactual.dev/ssclient/kiota/models"
 )
 
 // V2PipelineRequestBuilder builds and executes requests for operations under \api\v2\pipeline
 type V2PipelineRequestBuilder struct {
     i2ae4187f7daee263371cb1c977df639813ab50ffa529013b7437480d1ec0158f.BaseRequestBuilder
+}
+type V2PipelineRequestBuilderGetQueryParameters struct {
+    Description *string `uriparametername:"description"`
+    Uuid *string `uriparametername:"uuid"`
+}
+// V2PipelineRequestBuilderGetRequestConfiguration configuration for the request such as headers, query parameters, and middleware options.
+type V2PipelineRequestBuilderGetRequestConfiguration struct {
+    // Request headers
+    Headers *i2ae4187f7daee263371cb1c977df639813ab50ffa529013b7437480d1ec0158f.RequestHeaders
+    // Request options
+    Options []i2ae4187f7daee263371cb1c977df639813ab50ffa529013b7437480d1ec0158f.RequestOption
+    // Request query parameters
+    QueryParameters *V2PipelineRequestBuilderGetQueryParameters
 }
 // ByUuid gets an item from the go.artefactual.dev/ssclient/kiota.api.v2.pipeline.item collection
 // returns a *V2PipelineWithUuItemRequestBuilder when successful
@@ -23,7 +38,7 @@ func (m *V2PipelineRequestBuilder) ByUuid(uuid string)(*V2PipelineWithUuItemRequ
 // NewV2PipelineRequestBuilderInternal instantiates a new V2PipelineRequestBuilder and sets the default values.
 func NewV2PipelineRequestBuilderInternal(pathParameters map[string]string, requestAdapter i2ae4187f7daee263371cb1c977df639813ab50ffa529013b7437480d1ec0158f.RequestAdapter)(*V2PipelineRequestBuilder) {
     m := &V2PipelineRequestBuilder{
-        BaseRequestBuilder: *i2ae4187f7daee263371cb1c977df639813ab50ffa529013b7437480d1ec0158f.NewBaseRequestBuilder(requestAdapter, "{+baseurl}/api/v2/pipeline", pathParameters),
+        BaseRequestBuilder: *i2ae4187f7daee263371cb1c977df639813ab50ffa529013b7437480d1ec0158f.NewBaseRequestBuilder(requestAdapter, "{+baseurl}/api/v2/pipeline{?description*,uuid*}", pathParameters),
     }
     return m
 }
@@ -32,4 +47,37 @@ func NewV2PipelineRequestBuilder(rawUrl string, requestAdapter i2ae4187f7daee263
     urlParams := make(map[string]string)
     urlParams["request-raw-url"] = rawUrl
     return NewV2PipelineRequestBuilderInternal(urlParams, requestAdapter)
+}
+// returns a PipelineListable when successful
+func (m *V2PipelineRequestBuilder) Get(ctx context.Context, requestConfiguration *V2PipelineRequestBuilderGetRequestConfiguration)(i2b7a3625368152c59661ed1a63c26960f7e9cda05d0fbc8e5d79ac57ca250e0a.PipelineListable, error) {
+    requestInfo, err := m.ToGetRequestInformation(ctx, requestConfiguration);
+    if err != nil {
+        return nil, err
+    }
+    res, err := m.BaseRequestBuilder.RequestAdapter.Send(ctx, requestInfo, i2b7a3625368152c59661ed1a63c26960f7e9cda05d0fbc8e5d79ac57ca250e0a.CreatePipelineListFromDiscriminatorValue, nil)
+    if err != nil {
+        return nil, err
+    }
+    if res == nil {
+        return nil, nil
+    }
+    return res.(i2b7a3625368152c59661ed1a63c26960f7e9cda05d0fbc8e5d79ac57ca250e0a.PipelineListable), nil
+}
+// returns a *RequestInformation when successful
+func (m *V2PipelineRequestBuilder) ToGetRequestInformation(ctx context.Context, requestConfiguration *V2PipelineRequestBuilderGetRequestConfiguration)(*i2ae4187f7daee263371cb1c977df639813ab50ffa529013b7437480d1ec0158f.RequestInformation, error) {
+    requestInfo := i2ae4187f7daee263371cb1c977df639813ab50ffa529013b7437480d1ec0158f.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(i2ae4187f7daee263371cb1c977df639813ab50ffa529013b7437480d1ec0158f.GET, m.BaseRequestBuilder.UrlTemplate, m.BaseRequestBuilder.PathParameters)
+    if requestConfiguration != nil {
+        if requestConfiguration.QueryParameters != nil {
+            requestInfo.AddQueryParameters(*(requestConfiguration.QueryParameters))
+        }
+        requestInfo.Headers.AddAll(requestConfiguration.Headers)
+        requestInfo.AddRequestOptions(requestConfiguration.Options)
+    }
+    requestInfo.Headers.TryAdd("Accept", "application/json")
+    return requestInfo, nil
+}
+// WithUrl returns a request builder with the provided arbitrary URL. Using this method means any other path or query parameters are ignored.
+// returns a *V2PipelineRequestBuilder when successful
+func (m *V2PipelineRequestBuilder) WithUrl(rawUrl string)(*V2PipelineRequestBuilder) {
+    return NewV2PipelineRequestBuilder(rawUrl, m.BaseRequestBuilder.RequestAdapter);
 }

--- a/kiota/kiota-lock.json
+++ b/kiota/kiota-lock.json
@@ -1,8 +1,8 @@
 {
-  "descriptionHash": "14BA7C9E2AFA958CC3F77DE26BDE82E3996A95D7F0F16F6BAC7EFA239158FCB1B6D8A1E77C74527CCBAE6F184AA5BF5A537E2717B01D25BCE20730A620901530",
-  "descriptionLocation": "../typespec/tsp-output/@typespec/openapi3/openapi.yaml",
+  "descriptionHash": "D962F2127517001E5AEB7D86394F2C12B144A137E7758950B2C88B5AD02896891315C8D3544CF859CC343D149B6E8789EA397DA5B325C58BFFC3DDB355C11DB7",
+  "descriptionLocation": "../typespec/tsp-output/@typespec/openapi3/openapi.v1.yaml",
   "lockFileVersion": "1.0.0",
-  "kiotaVersion": "1.13.0",
+  "kiotaVersion": "1.14.0",
   "clientClassName": "Client",
   "clientNamespaceName": "go.artefactual.dev/ssclient/kiota",
   "language": "Go",

--- a/kiota/models/pipeline_list.go
+++ b/kiota/models/pipeline_list.go
@@ -1,0 +1,121 @@
+package models
+
+import (
+    i878a80d2330e89d26896388a3f487eef27b0a0e6c010c493bf80be1452208f91 "github.com/microsoft/kiota-abstractions-go/serialization"
+)
+
+type PipelineList struct {
+    // Stores additional data not described in the OpenAPI description found when deserializing. Can be used for serialization as well.
+    additionalData map[string]any
+    // The meta property
+    meta ListResponseMetaable
+    // The objects property
+    objects []Pipelineable
+}
+// NewPipelineList instantiates a new PipelineList and sets the default values.
+func NewPipelineList()(*PipelineList) {
+    m := &PipelineList{
+    }
+    m.SetAdditionalData(make(map[string]any))
+    return m
+}
+// CreatePipelineListFromDiscriminatorValue creates a new instance of the appropriate class based on discriminator value
+// returns a Parsable when successful
+func CreatePipelineListFromDiscriminatorValue(parseNode i878a80d2330e89d26896388a3f487eef27b0a0e6c010c493bf80be1452208f91.ParseNode)(i878a80d2330e89d26896388a3f487eef27b0a0e6c010c493bf80be1452208f91.Parsable, error) {
+    return NewPipelineList(), nil
+}
+// GetAdditionalData gets the AdditionalData property value. Stores additional data not described in the OpenAPI description found when deserializing. Can be used for serialization as well.
+// returns a map[string]any when successful
+func (m *PipelineList) GetAdditionalData()(map[string]any) {
+    return m.additionalData
+}
+// GetFieldDeserializers the deserialization information for the current model
+// returns a map[string]func(i878a80d2330e89d26896388a3f487eef27b0a0e6c010c493bf80be1452208f91.ParseNode)(error) when successful
+func (m *PipelineList) GetFieldDeserializers()(map[string]func(i878a80d2330e89d26896388a3f487eef27b0a0e6c010c493bf80be1452208f91.ParseNode)(error)) {
+    res := make(map[string]func(i878a80d2330e89d26896388a3f487eef27b0a0e6c010c493bf80be1452208f91.ParseNode)(error))
+    res["meta"] = func (n i878a80d2330e89d26896388a3f487eef27b0a0e6c010c493bf80be1452208f91.ParseNode) error {
+        val, err := n.GetObjectValue(CreateListResponseMetaFromDiscriminatorValue)
+        if err != nil {
+            return err
+        }
+        if val != nil {
+            m.SetMeta(val.(ListResponseMetaable))
+        }
+        return nil
+    }
+    res["objects"] = func (n i878a80d2330e89d26896388a3f487eef27b0a0e6c010c493bf80be1452208f91.ParseNode) error {
+        val, err := n.GetCollectionOfObjectValues(CreatePipelineFromDiscriminatorValue)
+        if err != nil {
+            return err
+        }
+        if val != nil {
+            res := make([]Pipelineable, len(val))
+            for i, v := range val {
+                if v != nil {
+                    res[i] = v.(Pipelineable)
+                }
+            }
+            m.SetObjects(res)
+        }
+        return nil
+    }
+    return res
+}
+// GetMeta gets the meta property value. The meta property
+// returns a ListResponseMetaable when successful
+func (m *PipelineList) GetMeta()(ListResponseMetaable) {
+    return m.meta
+}
+// GetObjects gets the objects property value. The objects property
+// returns a []Pipelineable when successful
+func (m *PipelineList) GetObjects()([]Pipelineable) {
+    return m.objects
+}
+// Serialize serializes information the current object
+func (m *PipelineList) Serialize(writer i878a80d2330e89d26896388a3f487eef27b0a0e6c010c493bf80be1452208f91.SerializationWriter)(error) {
+    {
+        err := writer.WriteObjectValue("meta", m.GetMeta())
+        if err != nil {
+            return err
+        }
+    }
+    if m.GetObjects() != nil {
+        cast := make([]i878a80d2330e89d26896388a3f487eef27b0a0e6c010c493bf80be1452208f91.Parsable, len(m.GetObjects()))
+        for i, v := range m.GetObjects() {
+            if v != nil {
+                cast[i] = v.(i878a80d2330e89d26896388a3f487eef27b0a0e6c010c493bf80be1452208f91.Parsable)
+            }
+        }
+        err := writer.WriteCollectionOfObjectValues("objects", cast)
+        if err != nil {
+            return err
+        }
+    }
+    {
+        err := writer.WriteAdditionalData(m.GetAdditionalData())
+        if err != nil {
+            return err
+        }
+    }
+    return nil
+}
+// SetAdditionalData sets the AdditionalData property value. Stores additional data not described in the OpenAPI description found when deserializing. Can be used for serialization as well.
+func (m *PipelineList) SetAdditionalData(value map[string]any)() {
+    m.additionalData = value
+}
+// SetMeta sets the meta property value. The meta property
+func (m *PipelineList) SetMeta(value ListResponseMetaable)() {
+    m.meta = value
+}
+// SetObjects sets the objects property value. The objects property
+func (m *PipelineList) SetObjects(value []Pipelineable)() {
+    m.objects = value
+}
+type PipelineListable interface {
+    i878a80d2330e89d26896388a3f487eef27b0a0e6c010c493bf80be1452208f91.AdditionalDataHolder
+    i878a80d2330e89d26896388a3f487eef27b0a0e6c010c493bf80be1452208f91.Parsable
+    GetMeta()(ListResponseMetaable)
+    GetObjects()([]Pipelineable)
+    SetMeta(value ListResponseMetaable)()
+    SetObjects(value []Pipelineable)()
+}

--- a/typespec/main.tsp
+++ b/typespec/main.tsp
@@ -1,18 +1,37 @@
 import "@typespec/http";
 import "@typespec/rest";
 import "@typespec/openapi3";
+import "@typespec/versioning";
 
 using TypeSpec.Http;
 using TypeSpec.Rest;
+using TypeSpec.Versioning;
 
 @service({
   title: "Archivematica Storage Service",
 })
 @route("/api/v2")
 @useAuth(ApiKeyAuth<ApiKeyLocation.header, "ApiKey">)
+@versioned(Versions)
 namespace Service {
+  enum Versions {
+    v1,
+  }
+
   @route("/pipeline")
   namespace Pipelines {
+    @get
+    op list(
+      @query
+      description?: string,
+
+      @query
+      uuid?: uuid,
+    ): {
+      @statusCode statusCode: 200;
+      @body list: PipelineList;
+    };
+
     @get
     op read(@path uuid: string): {
       @statusCode statusCode: 200;
@@ -24,10 +43,38 @@ namespace Service {
       @statusCode statusCode: 404;
     };
   }
+
   @route("/location")
   namespace Locations {
     @get
-    op list(): {
+    op list(
+      @query
+      description?: string,
+
+      @query
+      purpose?: LocationPurpose,
+
+      @query
+      quota?: integer,
+
+      @query("relative_path")
+      relativePath?: string,
+
+      @query
+      used?: integer,
+
+      @query
+      uuid?: uuid,
+
+      // TODO: enable all ORM filters, including across relationships.
+      // "space": ALL_WITH_RELATIONS
+      // "pipeline": ALL_WITH_RELATIONS
+
+      @query("pipeline__uuid")
+      pipelineId?: uuid,
+
+      ...ListOpQueries,
+    ): {
       @statusCode statusCode: 200;
       @body list: LocationList;
     };
@@ -80,11 +127,26 @@ scalar uuid extends string;
 @doc("Uniform Resource Identifier, e.g. \"/api/v2/space/141593ff-2a27-44a1-9de1-917573fa0f4a/\".")
 scalar uri extends string;
 
+model ListOpQueries {
+  @query("order_by")
+  orderBy?: string;
+
+  @query
+  limit?: integer;
+
+  @query
+  offset?: integer;
+}
+
 model Pipeline {
   description: string;
   remote_name: string;
   resource_uri: string;
   uuid: uuid;
+}
+
+model PipelineList {
+  ...ListResponse<Pipeline>;
 }
 
 enum LocationPurpose {

--- a/typespec/tsp-output/@typespec/openapi3/openapi.v1.yaml
+++ b/typespec/tsp-output/@typespec/openapi3/openapi.v1.yaml
@@ -1,13 +1,51 @@
 openapi: 3.0.0
 info:
   title: Archivematica Storage Service
-  version: 0.0.0
+  version: v1
 tags: []
 paths:
   /api/v2/location:
     get:
       operationId: Locations_list
-      parameters: []
+      parameters:
+        - name: description
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: purpose
+          in: query
+          required: false
+          schema:
+            $ref: '#/components/schemas/LocationPurpose'
+        - name: quota
+          in: query
+          required: false
+          schema:
+            type: integer
+        - name: relative_path
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: used
+          in: query
+          required: false
+          schema:
+            type: integer
+        - name: uuid
+          in: query
+          required: false
+          schema:
+            $ref: '#/components/schemas/uuid'
+        - name: pipeline__uuid
+          in: query
+          required: false
+          schema:
+            $ref: '#/components/schemas/uuid'
+        - $ref: '#/components/parameters/ListOpQueries.orderBy'
+        - $ref: '#/components/parameters/ListOpQueries.limit'
+        - $ref: '#/components/parameters/ListOpQueries.offset'
       responses:
         '200':
           description: The request has succeeded.
@@ -101,6 +139,27 @@ paths:
                 $ref: '#/components/schemas/Error'
         '404':
           description: The server cannot find the requested resource.
+  /api/v2/pipeline:
+    get:
+      operationId: Pipelines_list
+      parameters:
+        - name: description
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: uuid
+          in: query
+          required: false
+          schema:
+            $ref: '#/components/schemas/uuid'
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PipelineList'
   /api/v2/pipeline/{uuid}:
     get:
       operationId: Pipelines_read
@@ -128,6 +187,25 @@ paths:
 security:
   - ApiKeyAuth: []
 components:
+  parameters:
+    ListOpQueries.limit:
+      name: limit
+      in: query
+      required: false
+      schema:
+        type: integer
+    ListOpQueries.offset:
+      name: offset
+      in: query
+      required: false
+      schema:
+        type: integer
+    ListOpQueries.orderBy:
+      name: order_by
+      in: query
+      required: false
+      schema:
+        type: string
   schemas:
     Error:
       type: object
@@ -237,6 +315,22 @@ components:
           type: string
         uuid:
           $ref: '#/components/schemas/uuid'
+    PipelineList:
+      type: object
+      required:
+        - meta
+        - objects
+      properties:
+        meta:
+          $ref: '#/components/schemas/ListResponseMeta'
+        objects:
+          type: array
+          items:
+            $ref: '#/components/schemas/Pipeline'
+    Versions:
+      type: string
+      enum:
+        - v1
     moveFile:
       type: object
       required:


### PR DESCRIPTION
For example, filtering locations by purpose:

```go
purpose := models.DS_LOCATIONPURPOSE
reqConfig := &api.V2LocationRequestBuilderGetRequestConfiguration{
	QueryParameters: &api.V2LocationRequestBuilderGetQueryParameters{
		PurposeAsLocationPurpose: &purpose,
	},
}
listable, err := app.client.Api().V2().Location().Get(ctx, reqConfig)
if err != nil {
	return err
}
```

Pipeline list operation and filtering has also been included.