### PR TITLE
Include trailing slash and disable compression

### DIFF
--- a/ssclient.go
+++ b/ssclient.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
+	"time"
 
 	kabs "github.com/microsoft/kiota-abstractions-go"
 	khttp "github.com/microsoft/kiota-http-go"
@@ -12,14 +14,63 @@ import (
 )
 
 func New(httpClient *http.Client, baseURL, username, key string) (*kiota.Client, error) {
-	authProvider := NewStorageServiceAuthProvider(username, key)
-	adapter, err := khttp.NewNetHttpRequestAdapter(authProvider)
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+
+	if err := configureMiddleware(httpClient); err != nil {
+		return nil, fmt.Errorf("configure client middleware: %v", err)
+	}
+
+	adapter, err := khttp.NewNetHttpRequestAdapterWithParseNodeFactoryAndSerializationWriterFactoryAndHttpClient(
+		&authProvider{username: username, key: key},
+		nil,
+		nil,
+		httpClient,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("create client adapter: %v", err)
 	}
+
 	adapter.SetBaseUrl(baseURL)
 
 	return kiota.NewClient(adapter), nil
+}
+
+// configureMiddleware installs the middlewares needed by this client.
+func configureMiddleware(client *http.Client) error {
+	var middlewares []khttp.Middleware
+
+	userAgentOpts := khttp.UserAgentHandlerOptions{
+		Enabled:        true,
+		ProductName:    "ssclient-go",
+		ProductVersion: "v0",
+	}
+	compressionOpts := khttp.NewCompressionOptions(false)
+	retryOpts := khttp.RetryHandlerOptions{
+		ShouldRetry: func(delay time.Duration, executionCount int, request *http.Request, response *http.Response) bool {
+			// TODO: we use go-retryablehttp but this could be provided instead.
+			return false
+		},
+	}
+
+	// We rely on the default set of middlewares provided by Kiota with a small
+	// number of customizations.
+	middlewares, err := khttp.GetDefaultMiddlewaresWithOptions(
+		&userAgentOpts,
+		&compressionOpts,
+		&retryOpts,
+	)
+	if err != nil {
+		return err
+	}
+
+	// Introduce our middleware to inject the trailing slash.
+	middlewares = append(middlewares, appendTrailingSlashHandler{})
+
+	client.Transport = khttp.NewCustomTransportWithParentTransport(client.Transport, middlewares...)
+
+	return nil
 }
 
 type authProvider struct {
@@ -38,4 +89,26 @@ func (p *authProvider) AuthenticateRequest(ctx context.Context, request *kabs.Re
 	request.Headers.Add("Authorization", fmt.Sprintf("ApiKey %s:%s", p.username, p.key))
 
 	return nil
+}
+
+// appendTrailingSlashHandler is a middleware that ensures that the path has a
+// trailing slash when expected by Archivematica Storage Service API. This is
+// not something that we have not been able to describe using TypeSpec yet.
+type appendTrailingSlashHandler struct{}
+
+var useSlash = map[string]struct{}{
+	http.MethodPost:   {},
+	http.MethodPut:    {},
+	http.MethodPatch:  {},
+	http.MethodDelete: {},
+}
+
+func (middleware appendTrailingSlashHandler) Intercept(pipeline khttp.Pipeline, middlewareIndex int, req *http.Request) (*http.Response, error) {
+	if _, ok := useSlash[req.Method]; ok {
+		if !strings.HasSuffix(req.URL.Path, "/") {
+			req.URL.Path += "/"
+		}
+	}
+
+	return pipeline.Next(req, middlewareIndex)
 }

--- a/ssclient_test.go
+++ b/ssclient_test.go
@@ -7,8 +7,6 @@ import (
 	"reflect"
 	"testing"
 
-	kiotahttpgo "github.com/microsoft/kiota-http-go"
-
 	"go.artefactual.dev/ssclient"
 )
 
@@ -25,7 +23,7 @@ func TestClient(t *testing.T) {
 			"Accept":          {"application/json"},
 			"Accept-Encoding": {"gzip"},
 			"Authorization":   {"ApiKey test:test"},
-			"User-Agent":      {"kiota-go/" + kiotahttpgo.NewUserAgentHandlerOptions().ProductVersion},
+			"User-Agent":      {"ssclient-go/v0"},
 		}))
 
 		w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
I've run into more issues with the client when trying to copy files between locations.

- The default redirect handler in Kiota returns an error when sending a POST because the data we're sending can't be kept. This is actually a problem in TypeSpec because I haven't been able to describe paths with a trailing slash. While I'm hoping they can fix that in the openapi3 emitter at some point, what I've done in this PR is to inject a new middleware that introduces the trailing slash when needed.
- Compression was enabled by default and that was a problem in Storage Service because it wasn't handling the payload in my development environment. I've temporarily disabled it.

This is now working for me:

```go
origin := "/api/v2/location/5cbbf1f6-7abe-474e-8dda-9904083a1831/"
pipeline := "/api/v2/pipeline/97c991c6-432f-4e45-9f58-e6f432b62a97/"

var body models.MoveRequestable = models.NewMoveRequest()
body.SetOriginLocation(&origin)
body.SetPipeline(&pipeline)

moves := []models.MoveFileable{
	{
		move := &models.MoveFile{}
		src := "test"
		dst := "test"
		move.SetSource(&src)
		move.SetDestination(&dst)
		moves = append(moves, move)
	}
}
body.SetFiles(moves)

bytes, err := app.client.Location().ByUuid("df192133-3b13-4292-a219-50887d285cb3").Post(ctx, body, nil)
```