### PR TITLE
Always append slash to path

### DIFF
--- a/example/main_test.go
+++ b/example/main_test.go
@@ -37,7 +37,7 @@ func TestRun(t *testing.T) {
 	stdout := bytes.NewBuffer([]byte{})
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assertEqual(t, r.URL.Path, "/api/v2/location")
+		assertEqual(t, r.URL.Path, "/api/v2/location/")
 		assertEqual(t, r.Header, http.Header(map[string][]string{
 			"Accept":          {"application/json"},
 			"Accept-Encoding": {"gzip"},

--- a/ssclient.go
+++ b/ssclient.go
@@ -96,18 +96,9 @@ func (p *authProvider) AuthenticateRequest(ctx context.Context, request *kabs.Re
 // not something that we have not been able to describe using TypeSpec yet.
 type appendTrailingSlashHandler struct{}
 
-var useSlash = map[string]struct{}{
-	http.MethodPost:   {},
-	http.MethodPut:    {},
-	http.MethodPatch:  {},
-	http.MethodDelete: {},
-}
-
 func (middleware appendTrailingSlashHandler) Intercept(pipeline khttp.Pipeline, middlewareIndex int, req *http.Request) (*http.Response, error) {
-	if _, ok := useSlash[req.Method]; ok {
-		if !strings.HasSuffix(req.URL.Path, "/") {
-			req.URL.Path += "/"
-		}
+	if !strings.HasSuffix(req.URL.Path, "/") {
+		req.URL.Path += "/"
 	}
 
 	return pipeline.Next(req, middlewareIndex)

--- a/ssclient_test.go
+++ b/ssclient_test.go
@@ -18,7 +18,7 @@ func assertEqual(t *testing.T, got, want interface{}) {
 
 func TestClient(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assertEqual(t, r.URL.Path, "/api/v2/location")
+		assertEqual(t, r.URL.Path, "/api/v2/location/")
 		assertEqual(t, r.Header, http.Header(map[string][]string{
 			"Accept":          {"application/json"},
 			"Accept-Encoding": {"gzip"},


### PR DESCRIPTION
This PR updates appendTrailingSlashHandler to always append the slash regardless the HTTP method. There is no point in handling the 301 Moved Permanently redirect when we can just hit the right path.